### PR TITLE
Rewrite CMakeLists.txt and use improved Find*.cmake files to fix cmake building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,51 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 
-include(WiresharkPlugin)
+project(h4bcm-wireshark-plugin C CXX)
 
-# Plugin name and version info (major minor micro extra)
-set_module_info(h4bcm 1 1 0 0)
+cmake_minimum_required(VERSION 3.5)
+set(CMAKE_BACKWARDS_COMPATIBILITY 3.5)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+MESSAGE(${CMAKE_MODULE_PATH})
+
+find_package(Wireshark 3.4)
+
+if(Wireshark_FOUND)
+
+  MESSAGE(STATUS "Wireshark 3.4 libraries found in ${Wireshark_LIB_DIR}, performing a stand-alone plug-in build.")
+
+  if(NOT CMAKE_INSTALL_LIBDIR )
+    set(CMAKE_INSTALL_LIBDIR ~/.local/lib/wireshark/plugins/${Wireshark_VERSION_MAJOR}.${Wireshark_VERSION_MINOR}/epan)
+  endif(NOT CMAKE_INSTALL_LIBDIR )
+  MESSAGE(STATUS "Plug-in will be installed in: ${CMAKE_INSTALL_LIBDIR}")
+
+  INCLUDE(UseMakePluginReg)
+
+  set(GLIB2_MIN_VERSION 2.4.0)
+
+  find_package(GLIB2)
+  include_directories (${GLIB2_INCLUDE_DIRS})
+
+  include_directories (${Wireshark_INCLUDE_DIR})
+
+  IF(APPLE)
+    LINK_DIRECTORIES(/usr/local/lib)
+  ENDIF()
+
+  set(LINK_MODE_LIB SHARED)
+  set(LINK_MODE_MODULE MODULE)
+
+else(Wireshark_FOUND)
+
+  MESSAGE(STATUS "Wireshark 3.4 libraries not found, performing an in-tree Wireshark plug-in build.")
+
+  include(WiresharkPlugin)
+
+  # Plugin name and version info (major minor micro extra)
+  set_module_info(h4bcm 1 1 0 0)
+
+endif(Wireshark_FOUND)
 
 set(DISSECTOR_SRC
 	packet-h4bcm.c
@@ -35,14 +76,39 @@ register_plugin_files(plugin.c
 	${DISSECTOR_SRC}
 )
 
-add_plugin_library(h4bcm epan)
+if(Wireshark_FOUND)
 
-target_link_libraries(h4bcm epan)
+  add_library(h4bcm ${LINK_MODE_MODULE}
+                  ${PLUGIN_FILES}
+                  ${PLUGIN_RC_FILE}
+  )
 
-install_plugin(h4bcm epan)
+  set_target_properties(h4bcm PROPERTIES
+          PREFIX ""
+          LINK_FLAGS "${WS_LINK_FLAGS}"
+          FOLDER "Plugins"
+  )
 
-file(GLOB DISSECTOR_HEADERS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.h")
-CHECKAPI(
+  link_directories(${Wireshark_LIB_DIR})
+
+  target_link_libraries(h4bcm wireshark)
+
+  install(TARGETS h4bcm
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} NAMELINK_SKIP
+          RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+
+else(Wireshark_FOUND)
+
+  add_plugin_library(h4bcm epan)
+
+  target_link_libraries(h4bcm epan)
+
+  install_plugin(h4bcm epan)
+
+  file(GLOB DISSECTOR_HEADERS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.h")
+  CHECKAPI(
 	NAME
 	  h4bcm
 	SWITCHES
@@ -50,8 +116,9 @@ CHECKAPI(
 	SOURCES
 	  ${DISSECTOR_SRC}
 	  ${DISSECTOR_HEADERS}
-)
+  )
 
+endif(Wireshark_FOUND)
 #
 # Editor modelines  -  https://www.wireshark.org/tools/modelines.html
 #

--- a/cmake/FindWSLibrary.cmake
+++ b/cmake/FindWSLibrary.cmake
@@ -1,0 +1,37 @@
+#
+# - Find WS Library
+#  This function is a wrapper for find_library() that does handle vcpkg exported
+#  library directory structure
+
+function(FindWSLibrary OUTPUT_LIBRARY)
+    cmake_parse_arguments(
+        WS_LIB
+        ""
+        "WIN32_HINTS"
+        "NAMES;HINTS;PATHS"
+        ${ARGN}
+    )
+
+    if (WIN32)
+        find_library(${OUTPUT_LIBRARY}_DEBUG
+            NAMES ${WS_LIB_NAMES}
+            HINTS "${WS_LIB_WIN32_HINTS}/debug/lib"
+            PATHS ${WS_LIB_PATHS}
+        )
+        find_library(${OUTPUT_LIBRARY}_RELEASE
+            NAMES ${WS_LIB_NAMES}
+            HINTS "${WS_LIB_WIN32_HINTS}/lib"
+            PATHS ${WS_LIB_PATHS}
+        )
+
+        if (${OUTPUT_LIBRARY}_DEBUG AND ${OUTPUT_LIBRARY}_RELEASE)
+            set(${OUTPUT_LIBRARY} debug ${${OUTPUT_LIBRARY}_DEBUG} optimized ${${OUTPUT_LIBRARY}_RELEASE} PARENT_SCOPE)
+        endif()
+    else()
+        find_library(${OUTPUT_LIBRARY}
+            NAMES ${WS_LIB_NAMES}
+            HINTS ${WS_LIB_HINTS}
+            PATHS ${WS_LIB_PATHS}
+        )
+    endif()
+endfunction()

--- a/cmake/FindWSWinLibs.cmake
+++ b/cmake/FindWSWinLibs.cmake
@@ -1,0 +1,105 @@
+#
+# - Find WSWin Libs
+#  Due to the layout of the Wireshark Win support libs,
+#  CMake needs some support to find them
+#
+#  The function is passed the directory name to search for and the variable
+#  to set in the callers scope.
+
+function( FindWSWinLibs _WS_LIB_SEARCH_PATH _LIB_HINT_VAR )
+  if( WIN32 )
+    if( ARGN )
+      set( _PROJECT_LIB_DIR ${ARGN} )
+    else()
+      if( DEFINED ENV{WIRESHARK_LIB_DIR} )
+        # The buildbots set WIRESHARK_LIB_DIR but not WIRESHARK_BASE_DIR.
+        file( TO_CMAKE_PATH "$ENV{WIRESHARK_LIB_DIR}" _PROJECT_LIB_DIR )
+      else()
+        file( TO_CMAKE_PATH "$ENV{WIRESHARK_BASE_DIR}" _WS_BASE_DIR )
+        set( _PROJECT_LIB_DIR "${_WS_BASE_DIR}/wireshark-${WIRESHARK_TARGET_PLATFORM}-libs-3.4" )
+      endif()
+    endif()
+
+    file( GLOB _SUBDIR "${_PROJECT_LIB_DIR}/*" )
+    # We might be able to use $ENV{VSCMD_ARG_TGT_ARCH} here.
+    set (_vcpkg_arch x64)
+    if(WIRESHARK_TARGET_PLATFORM MATCHES "win32")
+      set (_vcpkg_arch x86)
+    endif()
+
+    foreach( _DIR ${_SUBDIR} )
+      if( IS_DIRECTORY ${_DIR} )
+        if( "${_DIR}" MATCHES ".*/${_WS_LIB_SEARCH_PATH}" )
+          set(_vcpkg_dir "${_DIR}/installed/${_vcpkg_arch}-windows")
+          if( IS_DIRECTORY "${_vcpkg_dir}")
+            set( ${_LIB_HINT_VAR} ${_vcpkg_dir} PARENT_SCOPE )
+          else()
+            set( ${_LIB_HINT_VAR} ${_DIR} PARENT_SCOPE )
+          endif()
+        endif()
+      endif()
+    endforeach()
+  endif()
+endfunction()
+
+# Add a single DLL
+function(AddWSWinDLL _PKG_NAME _PKG_HINTS _DLL_GLOB)
+  if(WIN32 AND ${_PKG_NAME}_FOUND)
+    string(TOUPPER ${_PKG_NAME} _PKG_VAR)
+    set ( ${_PKG_VAR}_DLL_DIR "${${_PKG_HINTS}}/bin"
+      CACHE PATH "Path to ${_PKG_NAME} DLL"
+    )
+    file( GLOB _pkg_dll RELATIVE "${${_PKG_VAR}_DLL_DIR}"
+      "${${_PKG_VAR}_DLL_DIR}/${_DLL_GLOB}.dll"
+    )
+    set ( ${_PKG_VAR}_DLL ${_pkg_dll}
+      CACHE STRING "${_PKG_NAME} DLL file name"
+    )
+    file( GLOB _pkg_pdb RELATIVE "${${_PKG_VAR}_DLL_DIR}"
+      "${${_PKG_VAR}_DLL_DIR}/${_DLL_GLOB}.pdb"
+    )
+    set ( ${_PKG_VAR}_PDB ${_pkg_pdb}
+      CACHE STRING "${_PKG_NAME} PDB file name"
+    )
+    mark_as_advanced( ${_PKG_VAR}_DLL_DIR ${_PKG_VAR}_DLL ${_PKG_VAR}_PDB )
+  else()
+    set( ${_PKG_VAR}_DLL_DIR )
+    set( ${_PKG_VAR}_DLL )
+  endif()
+endfunction()
+
+# Add a list of DLLs
+function(AddWSWinDLLS _PKG_NAME _PKG_HINTS) # ...DLL globs
+  if(WIN32 AND ${_PKG_NAME}_FOUND)
+    string(TOUPPER ${_PKG_NAME} _PKG_VAR)
+    set ( ${_PKG_VAR}_DLL_DIR "${${_PKG_HINTS}}/bin"
+      CACHE PATH "Path to ${_PKG_NAME} DLLs"
+    )
+
+    set (_pkg_dlls)
+    set (_pkg_pdbs)
+    foreach(_dll_glob ${ARGN})
+      file( GLOB _pkg_dll RELATIVE "${${_PKG_VAR}_DLL_DIR}"
+        "${${_PKG_VAR}_DLL_DIR}/${_dll_glob}.dll"
+      )
+      list(APPEND _pkg_dlls "${_pkg_dll}")
+      file( GLOB _pkg_pdb RELATIVE "${${_PKG_VAR}_DLL_DIR}"
+        "${${_PKG_VAR}_DLL_DIR}/${_dll_glob}.pdb"
+      )
+      list(APPEND _pkg_pdbs "${_pkg_pdb}")
+    endforeach()
+
+    set ( ${_PKG_VAR}_DLLS ${_pkg_dlls}
+    CACHE FILEPATH "${_PKG_NAME} DLL list"
+    )
+    set ( ${_PKG_VAR}_PDBS ${_pkg_pdbs}
+      CACHE FILEPATH "${_PKG_NAME} PDB list"
+    )
+
+    mark_as_advanced( ${_PKG_VAR}_DLL_DIR ${_PKG_VAR}_DLLS ${_PKG_VAR}_PDBS )
+  else()
+    set( ${_PKG_VAR}_DLL_DIR )
+    set( ${_PKG_VAR}_DLLS )
+    set( ${_PKG_VAR}_PDBS )
+  endif()
+endfunction()

--- a/cmake/FindWireshark.cmake
+++ b/cmake/FindWireshark.cmake
@@ -1,28 +1,39 @@
+# Locate the Wireshark library.
 #
-# Try to find the wireshark library and its includes
+# This file is meant to be copied into projects that want to use Wireshark.
+# It will search for WiresharkConfig.cmake, which ships with Wireshark
+# and will provide up-to-date buildsystem changes. Thus there should not be
+# any need to update FindWiresharkVc.cmake again after you integrated it into
+# your project.
 #
-# This snippet sets the following variables:
-#  WIRESHARK_FOUND             True if wireshark library got found
-#  WIRESHARK_INCLUDE_DIRS      Location of the wireshark headers 
-#  WIRESHARK_LIBRARIES         List of libraries to use wireshark
-#
-#  Copyright (c) 2011 Reinhold Kainhofer <reinhold@kainhofer.com>
-#
-#  Redistribution and use is allowed according to the terms of the New
-#  BSD license.
-#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
-#
+# This module defines the following variables:
+# Wireshark_FOUND
+# Wireshark_VERSION_MAJOR
+# Wireshark_VERSION_MINOR
+# Wireshark_VERSION_PATCH
+# Wireshark_VERSION
+# Wireshark_VERSION_STRING
+# Wireshark_INSTALL_DIR
+# Wireshark_PLUGIN_INSTALL_DIR
+# Wireshark_LIB_DIR
+# Wireshark_LIBRARY
+# Wireshark_INCLUDE_DIR
+# Wireshark_CMAKE_MODULES_DIR
 
-# wireshark does not install its library with pkg-config information,
-# so we need to manually find the libraries and headers
+find_package(Wireshark ${Wireshark_FIND_VERSION} QUIET NO_MODULE PATHS $ENV{HOME} /opt/Wireshark)
 
-FIND_PATH( WIRESHARK_INCLUDE_DIRS epan/packet.h PATH_SUFFIXES wireshark )
-FIND_LIBRARY( WIRESHARK_LIBRARIES wireshark )
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Wireshark CONFIG_MODE)
 
-# Report results
-IF ( WIRESHARK_LIBRARIES AND WIRESHARK_INCLUDE_DIRS )
-  SET( WIRESHARK_FOUND 1 )
-ELSE ( WIRESHARK_LIBRARIES AND WIRESHARK_INCLUDE_DIRS )
-  MESSAGE( SEND_ERROR "Could NOT find the wireshark library and headers" )
-ENDIF ( WIRESHARK_LIBRARIES AND WIRESHARK_INCLUDE_DIRS )
-
+MESSAGE(STATUS "Wireshark_FOUND: ${Wireshark_FOUND}")
+MESSAGE(STATUS "Wireshark_VERSION_MAJOR: ${Wireshark_VERSION_MAJOR}")
+MESSAGE(STATUS "Wireshark_VERSION_MINOR: ${Wireshark_VERSION_MINOR}")
+MESSAGE(STATUS "Wireshark_VERSION_PATCH: ${Wireshark_VERSION_PATCH}")
+MESSAGE(STATUS "Wireshark_VERSION: ${Wireshark_VERSION}")
+MESSAGE(STATUS "Wireshark_VERSION_STRING: ${Wireshark_VERSION_STRING}")
+MESSAGE(STATUS "Wireshark_INSTALL_DIR: ${Wireshark_INSTALL_DIR}")
+MESSAGE(STATUS "Wireshark_PLUGIN_INSTALL_DIR: ${Wireshark_PLUGIN_INSTALL_DIR}")
+MESSAGE(STATUS "Wireshark_LIB_DIR: ${Wireshark_LIB_DIR}")
+MESSAGE(STATUS "Wireshark_LIBRARY: ${Wireshark_LIBRARY}")
+MESSAGE(STATUS "Wireshark_INCLUDE_DIR: ${Wireshark_INCLUDE_DIR}")
+MESSAGE(STATUS "Wireshark_CMAKE_MODULES_DIR: ${Wireshark_CMAKE_MODULES_DIR}")


### PR DESCRIPTION
Fixes cmake building on Raspberry Pi 3b with Raspberry Pi OS, *should* also work for Ubuntu etc.

The commit features improved cmake scripts for locating Wireshark and GLIBC2 libs. Furthermore there is now differentiation between Wireshark standalone and in-tree plugin builds.

