### PR TITLE
Avoid including wireshark config.h file.

### DIFF
--- a/packet-btbrlmp.c
+++ b/packet-btbrlmp.c
@@ -21,8 +21,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#include "config.h"
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 

--- a/packet-h4bcm.c
+++ b/packet-h4bcm.c
@@ -23,8 +23,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#include "config.h"
-
 #include <epan/packet.h>
 #include <epan/prefs.h>
 #include <string.h>

--- a/tools/make-plugin-reg.py
+++ b/tools/make-plugin-reg.py
@@ -102,7 +102,7 @@ reg_code = ""
 reg_code += preamble
 
 reg_code += """
-#include "wireshark/config.h"
+#include <wireshark/ws_version.h>
 
 #include <gmodule.h>
 
@@ -131,8 +131,8 @@ for symbol in regs['codec_register']:
 # FIXME should not be hardcoded here but actually come from moduleinfo.h ...
 reg_code += """
 WS_DLL_PUBLIC_DEF const gchar plugin_version[] = "0.0.2";
-WS_DLL_PUBLIC_DEF const int plugin_want_major = VERSION_MAJOR;
-WS_DLL_PUBLIC_DEF const int plugin_want_minor = VERSION_MINOR;
+WS_DLL_PUBLIC_DEF const int plugin_want_major = WIRESHARK_VERSION_MAJOR;
+WS_DLL_PUBLIC_DEF const int plugin_want_minor = WIRESHARK_VERSION_MINOR;
 
 WS_DLL_PUBLIC void plugin_register(void);
 


### PR DESCRIPTION
Wireshark `config.h` file is not present in all installations.
See:
https://bugs.archlinux.org/task/63828
https://listman.redhat.com/archives/libvir-list/2020-September/msg00156.html

Fix compilation to not depend on it.